### PR TITLE
fix: get docktor url from env variable

### DIFF
--- a/app/controllers/users/users.password.server.controller.js
+++ b/app/controllers/users/users.password.server.controller.js
@@ -58,7 +58,7 @@ exports.forgot = function (req, res, next) {
             res.render('templates/reset-password-email', {
                 name: user.displayName,
                 appName: config.app.title,
-                url: 'http://' + req.headers.host + '/auth/reset/' + token
+                url: config.docktor_url + '/auth/reset/' + token
             }, function (err, emailHTML) {
                 done(err, emailHTML, user);
             });

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -1,6 +1,7 @@
 'use strict';
 
 module.exports = {
+	docktor_url: process.env.DOCKTOR_URL || 'http://localhost:3000',
 	db: 'mongodb://localhost/docktor-dev',
 	app: {
 		title: 'Docktor - Development Environment'

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -1,6 +1,7 @@
 'use strict';
 
 module.exports = {
+    docktor_url: process.env.DOCKTOR_URL || 'https://docktor.cdk.corp.sopra',
     db: 'mongodb://db_1:27017/docktor',
     assets: {
         lib: {


### PR DESCRIPTION
Wrong reset URL because of reverse proxy